### PR TITLE
Update next-transpile-modules.js

### DIFF
--- a/src/next-transpile-modules.js
+++ b/src/next-transpile-modules.js
@@ -261,8 +261,9 @@ const withTmInitializer = (modules = [], options = {}) => {
         // Make hot reloading work!
         // FIXME: not working on Wepback 5
         // https://github.com/vercel/next.js/issues/13039
+        const watchOptionsIgnored = Array.isArray(config.watchOptions.ignored) ? config.watchOptions.ignored : [config.watchOptions.ignored];
         config.watchOptions.ignored = [
-          ...config.watchOptions.ignored.filter((pattern) => pattern !== '**/node_modules/**'),
+          ...watchOptionsIgnored.filter((pattern) => pattern !== '**/node_modules/**'),
           `**node_modules/{${modules.map((mod) => `!(${mod})`).join(',')}}/**/*`,
         ];
 


### PR DESCRIPTION
Fixing the following error

```
TypeError: config.watchOptions.ignored.filter is not a function or its return value is not iterable
    at Object.webpack (/Users/manish/projects/kripaluras-rn/node_modules/next-transpile-modules/src/next-transpile-modules.js:265:42)
    at Object.webpack (/Users/manish/projects/kripaluras-rn/node_modules/next-fonts/index.js:42:27)
    at Object.webpack (/Users/manish/projects/kripaluras-rn/node_modules/next-images/index.js:63:27)
    at Object.webpack (/Users/manish/projects/kripaluras-rn/node_modules/@expo/next-adapter/build/index.js:39:35)
    at getBaseWebpackConfig (/Users/manish/projects/kripaluras-rn/node_modules/next/dist/build/webpack-config.js:2147:32)
    at async Promise.all (index 0)
    at async Span.traceAsyncFn (/Users/manish/projects/kripaluras-rn/node_modules/next/dist/trace/trace.js:103:20)
    at async Span.traceAsyncFn (/Users/manish/projects/kripaluras-rn/node_modules/next/dist/trace/trace.js:103:20)
    at async HotReloader.start (/Users/manish/projects/kripaluras-rn/node_modules/next/dist/server/dev/hot-reloader.js:573:30)
    at async DevServer.prepareImpl (/Users/manish/projects/kripaluras-rn/node_modules/next/dist/server/dev/next-dev-server.js:685:9)
    at async NextServer.prepare (/Users/manish/projects/kripaluras-rn/node_modules/next/dist/server/next.js:165:13)
    at async Server.<anonymous> (/Users/manish/projects/kripaluras-rn/node_modules/next/dist/server/lib/render-server.js:136:17) {
  type: 'TypeError'
}

```